### PR TITLE
Update Dockerfile - 

### DIFF
--- a/pi_server/Dockerfile
+++ b/pi_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.7.13-buster
 
 COPY . /tmp
 

--- a/pi_server/setup.py
+++ b/pi_server/setup.py
@@ -4,7 +4,7 @@ setup(
     name="pi_server",
     version="0.1.0",
     packages=find_packages(exclude=["tests"]),
-    install_requires=["flask==2.0.3"],#, "RPi.GPIO==0.7.1"],
+    install_requires=["flask==2.0.3", "RPi.GPIO==0.7.0"],
     extras_require={"dev": ["pytest", "mypy", "black"]},
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
FROM python:3.7.13-buster and modification to version 0.7.0 of the package RPi.GPIO